### PR TITLE
Add support for PX4 and running in SITL

### DIFF
--- a/pong.py
+++ b/pong.py
@@ -83,7 +83,7 @@ for cop in cops:
 
 i = 1
 
-if False: #trying safetakeoff for now
+if True: #trying safetakeoff for now
     for cop in cops:
         cop.setmode(custom_mode = "OFFBOARD")
         cop.arm()
@@ -91,7 +91,8 @@ if False: #trying safetakeoff for now
 
         cop.takeoff_velocity(alt = 1.0) # very short
 
-        i = i +1
+        i = i + 1
+        print("starting vehicle %s" % i)
 
 print "ready"
 
@@ -121,8 +122,8 @@ lstick = 0.0
 center_x = 0.0
 center_y = 0.0
 
-if True:
-    velocity_goto.SafeTakeoff(cops, offs_x, offs_y, alt = 10.0)
+if False:
+    velocity_goto.SafeTakeoff(cops, offs_x, offs_y, alt=10.0)
 
 while True:
     print " "
@@ -251,5 +252,3 @@ velocity_goto.SmartRTL(cops)
 print "so long!"
 
 time.sleep(1.0)
-
-

--- a/pong.py
+++ b/pong.py
@@ -220,17 +220,18 @@ while True:
         ls = (cops[1].cur_pos_y + cops[2].cur_pos_y)/2.0
         rs = (cops[3].cur_pos_y + cops[4].cur_pos_y)/2.0
 
-        if cops[0].cur_pos_x - center_x > 5.0:
+        if cops[0].cur_pos_x - center_x > 5.0 and ball_dir > 0:
             if abs(cops[0].cur_pos_y - rs) < 2.5:
                 ball_dir = -1.0
                 print "SLAM!"
 
-        if cops[0].cur_pos_x - center_x < -5.0:            
+        if cops[0].cur_pos_x - center_x < -5.0 and ball_dir < 0:
             if abs(cops[0].cur_pos_y - ls) < 2.5:
                 ball_dir = 1.0
                 print "SLAM!"
 
-        if abs(cops[0].cur_pos_x - center_x) > 7.0:
+        if cops[0].cur_pos_x - center_x > 9.0 and ball_dir > 0 or \
+            cops[0].cur_pos_x - center_x < -9.0 and ball_dir < 0:
             print " "
             print " "
             print "DAAAAAMN YOU SUCK! TRY AGAIN!"

--- a/pong.py
+++ b/pong.py
@@ -1,4 +1,5 @@
 from nav_msgs.msg import Odometry
+from sensor_msgs.msg import Joy
 import std_msgs
 import rosnode
 import roslib
@@ -13,6 +14,8 @@ import ast
 import os
 
 import velocity_goto
+
+SIMULATION = False
 
 class artoo:
     def __init__(self):
@@ -51,6 +54,34 @@ class artoo:
 
     def start_subbing(self):
         stick_sub = rospy.Subscriber("sticks", std_msgs.msg.String, self.handle_sticks)
+
+class joy:
+    def __init__(self):
+        self.stick_map = []
+
+        self.mod_scalar = 1.0
+
+        self.x_offset = 0.0
+        self.y_offset = 0.0
+        self.z_offset = 0.0
+
+        self.fin_x = 0.0
+        self.fin_y = 0.0
+        self.fin_z = 0.0
+
+        for i in range(8):
+            self.stick_map.append(0.0)
+
+    def handle_joystick(self, msg):
+        self.stick_map = msg.axes
+
+        self.x_offset = self.stick_map[1] * self.mod_scalar
+        self.y_offset = -self.stick_map[2] * self.mod_scalar
+        self.z_offset = self.stick_map[0]
+
+    def start_subbing(self):
+        stick_sub = rospy.Subscriber("joy", Joy, self.handle_joystick)
+
 
 class buttons:
     def __init__(self):
@@ -99,7 +130,10 @@ print "ready"
 b = buttons()
 b.start_subbing()
 
-a = artoo()
+if SIMULATION:
+    a = joy()
+else:
+    a = artoo()
 a.start_subbing()
 
 a.fin_x = cops[0].cur_pos_x

--- a/pong.py
+++ b/pong.py
@@ -116,19 +116,6 @@ for cop in cops:
 
 i = 1
 
-if True: #trying safetakeoff for now
-    for cop in cops:
-        cop.setmode(custom_mode = "OFFBOARD")
-        cop.arm()
-        time.sleep(0.1)
-
-        cop.takeoff_velocity(alt = 1.0) # very short
-
-        i = i + 1
-        print("starting vehicle %s" % i)
-
-print "ready"
-
 b = buttons()
 b.start_subbing()
 
@@ -158,8 +145,7 @@ lstick = 0.0
 center_x = 0.0
 center_y = 0.0
 
-if False:
-    velocity_goto.SafeTakeoff(cops, offs_x, offs_y, alt=10.0)
+velocity_goto.SafeTakeoff(cops, offs_x, offs_y, alt=10.0)
 
 while True:
     print " "

--- a/pong.py
+++ b/pong.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from nav_msgs.msg import Odometry
 from sensor_msgs.msg import Joy
 import std_msgs

--- a/velocity_goto.py
+++ b/velocity_goto.py
@@ -20,7 +20,7 @@ import threading
 import thread
 from random import randint
 
-IS_APM = False
+IS_APM = True
 VELOCITY_CAP = 1.0
 
 NAMESPACE_PREFIX = '/iris_'

--- a/velocity_goto.py
+++ b/velocity_goto.py
@@ -361,8 +361,10 @@ class SafeTakeoff:
         last = 0
 
         for i in range(len(self.sorted_ids[::-1])):
-            # self.cops[i].setmode(custom_mode = "OFFBOARD")
-            self.cops[i].setmode(custom_mode = "AUTO.TAKEOFF")
+            if IS_APM:
+                self.cops[i].setmode(custom_mode = "AUTO.TAKEOFF")
+            else:
+                self.cops[i].setmode(custom_mode = "OFFBOARD")
 
             self.cops[i].arm()
             self.cops[i].takeoff_velocity(alt = alt + i*2.5)

--- a/velocity_goto.py
+++ b/velocity_goto.py
@@ -7,6 +7,7 @@ from math import *
 from nav_msgs.msg import Odometry
 from sensor_msgs.msg import NavSatFix
 import geometry_msgs.msg
+from geometry_msgs.msg import TwistStamped
 import mavros
 import mavros_msgs.srv
 from mavros import setpoint as SP
@@ -19,13 +20,15 @@ import threading
 import thread
 from random import randint
 
-IS_APM = True
+IS_APM = False
 VELOCITY_CAP = 1.0
+
+NAMESPACE_PREFIX = '/iris_'
 
 class posVel:
     def __init__(self, copter_id = "1"):
         self.copter_id = copter_id
-        mavros_string = "/copter"+copter_id+"/mavros"
+        mavros_string = NAMESPACE_PREFIX + copter_id + "/mavros"
         mavros.set_namespace(mavros_string)  # initialize mavros module with default namespace
 
         self.mavros_string = mavros_string
@@ -59,9 +62,9 @@ class posVel:
         self.button_sub = rospy.Subscriber("abpause_buttons", std_msgs.msg.String, self.handle_buttons)
 
         # publisher for mavros/copter*/setpoint_position/local
-        self.pub_vel = SP.get_pub_velocity_cmd_vel(queue_size=10)
+        self.pub_vel = rospy.Publisher(mavros_string + '/setpoint_velocity/cmd_vel', TwistStamped, queue_size=10)
         # subscriber for mavros/copter*/local_position/local
-        self.sub = rospy.Subscriber(mavros.get_topic('local_position', 'local'), SP.PoseStamped, self.temp)
+        self.sub = rospy.Subscriber(mavros_string + 'local_position/local', SP.PoseStamped, self.temp)
 
     def handle_buttons(self, msg):
         self.click = str(msg)[6:]
@@ -110,7 +113,7 @@ class posVel:
         arm = rospy.ServiceProxy(self.mavros_string+'/cmd/arming', mavros_msgs.srv.CommandBool)  
         print "Disarm: ", arm(False)
 
-    def setmode(self,base_mode=0,custom_mode="OFFBOARD",delay=0.1):
+    def setmode(self,base_mode=216,custom_mode="OFFBOARD",delay=0.1):
         set_mode = rospy.ServiceProxy(self.mavros_string+'/set_mode', mavros_msgs.srv.SetMode)  
         if IS_APM:
             if custom_mode == "OFFBOARD":
@@ -126,10 +129,10 @@ class posVel:
         time.sleep(delay)
 
     def takeoff_velocity(self, alt=7):
-        self.alt_control = False
-        if self.cur_alt < alt - 1:
-            print "CUR ALT: ", self.cur_alt, "GOAL: ", alt
-            #self.set_velocity(0, 0, 1.5)
+        self.alt_control = False ## TODO(tfoote) why? Update sets it to true
+        while self.cur_alt < alt - 1:
+            # print "CUR ALT: ", self.cur_alt, "GOAL: ", alt
+            self.set_velocity(0, 0, -5.5)
             self.update(self.cur_pos_x, self.cur_pos_y, alt)
  
         time.sleep(0.1)
@@ -252,10 +255,16 @@ class posVel:
             else:
                 msg.twist.linear = geometry_msgs.msg.Vector3(self.vx*magnitude, self.vy*magnitude, self.vz*magnitude)
 
-
-            self.pub_vel.publish(msg)
+            try:
+                self.pub_vel.publish(msg)
+            except rospy.exceptions.ROSException as ex:
+                print "exception!! %s" % ex
+                print self.pub_vel
             
-            rate.sleep()
+            try:
+                rate.sleep()
+            except rospy.exceptions.ROSException as ex:
+                print "exception in rate!! %s" % ex
             i += 1
 
     def land_velocity(self):
@@ -352,12 +361,11 @@ class SafeTakeoff:
         last = 0
 
         for i in range(len(self.sorted_ids[::-1])):
-            self.cops[i].setmode(custom_mode = "OFFBOARD")
+            # self.cops[i].setmode(custom_mode = "OFFBOARD")
+            self.cops[i].setmode(custom_mode = "AUTO.TAKEOFF")
 
             self.cops[i].arm()
-
             self.cops[i].takeoff_velocity(alt = alt + i*2.5)
-
             if sequential:
                 while self.cops[i].cur_alt < alt + i*2.5 - 1.0:
                     self.cops[i].update(self.cops[i].cur_pos_x, self.cops[i].cur_pos_y, alt + i*2.5)
@@ -398,17 +406,16 @@ if __name__ == '__main__':
     print "set mode"
     pv.setmode(custom_mode="OFFBOARD")
     pv.arm()
+    pv.setmode(custom_mode="OFFBOARD") # Needed after for px4
     time.sleep(0.1)
     pv.takeoff_velocity()
     time.sleep(0.1)
     print "out of takeoff"
 
     # Send copter to current coordinate at 40m
-    pv.update(pv.get_lat_lon_alt()[0], pv.get_lat_lon_alt()[1], 40.0)
-    
-    while not pv.reached:
+    pv.update(pv.get_lat_lon_alt()[0]+10, pv.get_lat_lon_alt()[1], 15.0)
+    while not pv.reached and not rospy.is_shutdown():
         time.sleep(0.025)
-
     print "at gps, waiting"
     time.sleep(2.0)
 
@@ -418,4 +425,3 @@ if __name__ == '__main__':
     SmartRTL(copters)
 
     print "Landed!"
-


### PR DESCRIPTION
These changes let you run the demo in gazebo with the PX4 SITL stack. 

Here's a screen capture of the resultant demo: https://www.youtube.com/watch?v=wnfG5ulkkek

I tried to make sure all the changes are backwards compatible for the current demo. 

The other change is that it makes the simulation version use a generic ROS joystick instead of the Artoo class. In the future it might make sense to create a ROS node that publishes standard Joy message publisher from the Artoo. This would decrease the difference between operating on a live system and a simulated one as well as transitioning between vehicles with potentially different controllers.

This is leveraging some of the infrastructure from an ongoing project available at: https://github.com/osrf/uctf In the future I will work to document how to reproduce this demo in full once the development on uctf slows down. 
